### PR TITLE
feat: payments via keplr

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,12 +12,13 @@
         "@cosmjs/stargate": "^0.32.3",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@keplr-wallet/cosmos": "^0.12.107",
+        "@keplr-wallet/types": "^0.12.107",
         "@mui/icons-material": "^5.15.20",
         "@mui/material": "^5.15.20",
         "@nillion/client-web": "file:npm-nillion-client-web-nightly-v2024-06-27-7db213f55.tgz",
         "@tailwindcss/forms": "^0.5.7",
         "@types/react-router-dom": "^5.3.3",
-        "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
         "react": "^18.3.1",
         "react-copy-to-clipboard": "^5.1.0",
@@ -38,6 +39,7 @@
         "@types/react-syntax-highlighter": "^15.5.13",
         "autoprefixer": "^10.4.19",
         "babel-loader": "^9.1.3",
+        "buffer": "^6.0.3",
         "copy-webpack-plugin": "^12.0.2",
         "css-loader": "^7.1.2",
         "dotenv": "^16.4.5",
@@ -992,6 +994,125 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@ethersproject/address": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.7.0.tgz",
+      "integrity": "sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/keccak256": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "@ethersproject/rlp": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/bignumber": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.7.0.tgz",
+      "integrity": "sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0",
+        "bn.js": "^5.2.1"
+      }
+    },
+    "node_modules/@ethersproject/bytes": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.7.0.tgz",
+      "integrity": "sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
+    "node_modules/@ethersproject/keccak256": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.7.0.tgz",
+      "integrity": "sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "js-sha3": "0.8.0"
+      }
+    },
+    "node_modules/@ethersproject/logger": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.7.0.tgz",
+      "integrity": "sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@ethersproject/rlp": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.7.0.tgz",
+      "integrity": "sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/logger": "^5.7.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.3.tgz",
@@ -1207,6 +1328,89 @@
       },
       "peerDependencies": {
         "tslib": "2"
+      }
+    },
+    "node_modules/@keplr-wallet/common": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/common/-/common-0.12.107.tgz",
+      "integrity": "sha512-23/3/FFKqdEdy1iF9PVEGkRFM8pZW/zw65WzZuqTSH3LG2gxoBqY2f4o1Z7wEaurGJ8nYObIdqYBRwKBWBvbxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@keplr-wallet/crypto": "0.12.107",
+        "@keplr-wallet/types": "0.12.107",
+        "buffer": "^6.0.3",
+        "delay": "^4.4.0"
+      }
+    },
+    "node_modules/@keplr-wallet/cosmos": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/cosmos/-/cosmos-0.12.107.tgz",
+      "integrity": "sha512-LxU0sHqvNUh4gM6/02wyVp7PQE269xBGz18z/o9bNcJow2BUcrNx/+4idHvzh7xZxBKpfdAjRghcKZP7ajsupA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/address": "^5.6.0",
+        "@keplr-wallet/common": "0.12.107",
+        "@keplr-wallet/crypto": "0.12.107",
+        "@keplr-wallet/proto-types": "0.12.107",
+        "@keplr-wallet/simple-fetch": "0.12.107",
+        "@keplr-wallet/types": "0.12.107",
+        "@keplr-wallet/unit": "0.12.107",
+        "bech32": "^1.1.4",
+        "buffer": "^6.0.3",
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.2"
+      }
+    },
+    "node_modules/@keplr-wallet/crypto": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/crypto/-/crypto-0.12.107.tgz",
+      "integrity": "sha512-XlQbrpsgZ98r2k6Z17GY4leXLlY6Oceo5vTgKn1ljxMyoWydGsvc4YN3y4GfTDNS5SXSsHNHOKUrNk4dKr4m7w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ethersproject/keccak256": "^5.5.0",
+        "bip32": "^2.0.6",
+        "bip39": "^3.0.3",
+        "bs58check": "^2.1.2",
+        "buffer": "^6.0.3",
+        "crypto-js": "^4.0.0",
+        "elliptic": "^6.5.3",
+        "sha.js": "^2.4.11"
+      }
+    },
+    "node_modules/@keplr-wallet/proto-types": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/proto-types/-/proto-types-0.12.107.tgz",
+      "integrity": "sha512-tRYRFGaRjid3+mD9fEWMXG7S5P5Jdlb0LZJh5xj8VwgAiHBLpMXLjqWwl1rcAQm9imn/kgr2gSKkS2o/sTOMTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "^6.11.2"
+      }
+    },
+    "node_modules/@keplr-wallet/simple-fetch": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.107.tgz",
+      "integrity": "sha512-vHXfusmfKTdgBCMnBI4Ye7HLppyIgWN2nWPi3UGshE4PJJAde2yCcQi+UCWBSdVSMiJtnzGCsv8G3XFrx+4+zg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@keplr-wallet/types": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/types/-/types-0.12.107.tgz",
+      "integrity": "sha512-jBpjJO+nNL8cgsJLjZYoq84n+7nXHDdztTgRMVnnomFb+Vy0FVIEI8VUl89ImmHDUImDd0562ywsvA496/0yCA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "long": "^4.0.0"
+      }
+    },
+    "node_modules/@keplr-wallet/unit": {
+      "version": "0.12.107",
+      "resolved": "https://registry.npmjs.org/@keplr-wallet/unit/-/unit-0.12.107.tgz",
+      "integrity": "sha512-L4a3Nyric0OL+HfACed/cxukOuDZpsmAr5uAagUsHHCLUKyKkve96YwOIwLfyqx7sV18BR7kCTyza49GDG1pzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@keplr-wallet/types": "0.12.107",
+        "big-integer": "^1.6.48",
+        "utility-types": "^3.10.0"
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
@@ -2432,6 +2636,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -2462,6 +2675,15 @@
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2471,6 +2693,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip32": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/bip32/-/bip32-2.0.6.tgz",
+      "integrity": "sha512-HpV5OMLLGTjSVblmrtYRfFFKuQB+GArM0+XP8HGWfJ5vxYBqo+DesvJwOdC2WJ3bCkZShGf0QIfoIpeomVzVdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "10.12.18",
+        "bs58check": "^2.1.1",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "tiny-secp256k1": "^1.1.3",
+        "typeforce": "^1.11.5",
+        "wif": "^2.0.6"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bip32/node_modules/@types/node": {
+      "version": "10.12.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
+      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "license": "MIT"
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/bn.js": {
@@ -2663,6 +2927,26 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "node_modules/bs58check": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
+      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58": "^4.0.0",
+        "create-hash": "^1.1.0",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -2681,6 +2965,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -3222,6 +3507,12 @@
         "node": "*"
       }
     },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
+    },
     "node_modules/css-loader": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
@@ -3417,6 +3708,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delay": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
+      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -4193,6 +4496,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -5405,6 +5714,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5821,6 +6136,12 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -8176,6 +8497,29 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
     },
+    "node_modules/tiny-secp256k1": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.6.tgz",
+      "integrity": "sha512-FmqJZGduTyvsr2cF3375fqGHUovSwDi/QytexX1Se4BPuPZpTE5Ftp5fg+EFSuEf3lhZqgCRjEG3ydUQ/aNiwA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "bn.js": "^4.11.8",
+        "create-hmac": "^1.1.7",
+        "elliptic": "^6.4.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/tiny-secp256k1/node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "license": "MIT"
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -8384,6 +8728,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typeforce": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/typeforce/-/typeforce-1.18.0.tgz",
+      "integrity": "sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
@@ -8480,6 +8830,15 @@
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==",
       "dev": true
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -8908,6 +9267,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/wif": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/wif/-/wif-2.0.6.tgz",
+      "integrity": "sha512-HIanZn1zmduSF+BQhkE+YXIbEiH0xPr1012QbFEGB0xsKqJii0/SqJjyn8dFv6y36kOznMgMB+LGcbZTJ1xACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bs58check": "<3.0.0"
       }
     },
     "node_modules/wildcard": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@cosmjs/stargate": "^0.32.3",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@keplr-wallet/cosmos": "^0.12.107",
+    "@keplr-wallet/types": "^0.12.107",
     "@mui/icons-material": "^5.15.20",
     "@mui/material": "^5.15.20",
     "@nillion/client-web": "file:npm-nillion-client-web-nightly-v2024-06-27-7db213f55.tgz",

--- a/src/nillion/components/ComputeForm.tsx
+++ b/src/nillion/components/ComputeForm.tsx
@@ -1,15 +1,15 @@
-import React, { useState } from 'react';
-import * as nillion from '@nillion/client-web';
-import { getQuote } from '../helpers/getQuote';
+import React, { useState } from "react";
+import * as nillion from "@nillion/client-web";
+import { getQuote } from "../helpers/getQuote";
 import {
   createNilChainClientAndWalletFromPrivateKey,
-  payWithWalletFromPrivateKey,
-} from '../helpers/nillion';
-import { computeProgram } from '../helpers/compute';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import { CircularProgress, List, ListItem, ListItemText } from '@mui/material';
-import PayButton from './PayButton';
+  payWithWallet,
+} from "../helpers/nillion";
+import { computeProgram } from "../helpers/compute";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import { CircularProgress, List, ListItem, ListItemText } from "@mui/material";
+import { PayButton } from "./PayButton";
 
 interface ComputeParty {
   partyName: string;
@@ -52,7 +52,7 @@ const ComputeComponent: React.FC<ComputeProgramProps> = ({
 
       const operation = nillion.Operation.compute(
         programId,
-        additionalComputeValues
+        additionalComputeValues,
       );
       const quote = await getQuote({
         client: nillionClient,
@@ -74,10 +74,10 @@ const ComputeComponent: React.FC<ComputeProgramProps> = ({
       const [nilChainClient, nilChainWallet] =
         await createNilChainClientAndWalletFromPrivateKey();
 
-      const paymentReceipt = await payWithWalletFromPrivateKey(
+      const paymentReceipt = await payWithWallet(
         nilChainClient,
         nilChainWallet,
-        quote
+        quote,
       );
 
       setPaymentReceipt(paymentReceipt);
@@ -109,12 +109,12 @@ const ComputeComponent: React.FC<ComputeProgramProps> = ({
       </p>
       <br />
       <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
-        Get Quote{' '}
+        Get Quote{" "}
         {loadingQuote && (
           <CircularProgress
             size="14px"
             color="inherit"
-            style={{ marginLeft: '10px' }}
+            style={{ marginLeft: "10px" }}
           />
         )}
       </Button>

--- a/src/nillion/components/PayButton.tsx
+++ b/src/nillion/components/PayButton.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
-import { Box, Button, CircularProgress, List, ListItem } from '@mui/material';
-import CopyableString from './CopyableString';
+import React from "react";
+import { Box, Button, CircularProgress, List, ListItem } from "@mui/material";
+import CopyableString from "./CopyableString";
+import {
+  createNilChainClientAndWalletFromKeplr,
+  payWithWallet,
+} from "../helpers/nillion";
 
 interface PayButtonProps {
   buttonText: string;
@@ -10,7 +14,7 @@ interface PayButtonProps {
   listItems?: { displayText: string; copyText: string }[];
 }
 
-const PayButton: React.FC<PayButtonProps> = ({
+export const PayButton: React.FC<PayButtonProps> = ({
   buttonText,
   onClick,
   loading = false,
@@ -25,7 +29,7 @@ const PayButton: React.FC<PayButtonProps> = ({
           <CircularProgress
             size="14px"
             color="inherit"
-            style={{ marginLeft: '10px' }}
+            style={{ marginLeft: "10px" }}
           />
         )}
       </Button>
@@ -46,4 +50,27 @@ const PayButton: React.FC<PayButtonProps> = ({
   );
 };
 
-export default PayButton;
+interface PayButtonKeplrProps {
+  quote: any;
+  loading?: boolean;
+  displayList?: boolean;
+  listItems?: { displayText: string; copyText: string }[];
+}
+
+function payWithKeplr(quote: any) {
+  return (): void => {
+    createNilChainClientAndWalletFromKeplr().then(([client, wallet]) => {
+      payWithWallet(client, wallet, { quote: quote });
+    });
+  };
+}
+
+export const PayButtonKeplr: React.FC<PayButtonKeplrProps> = (props) => {
+  return (
+    <PayButton
+      buttonText="Pay with Keplr"
+      onClick={payWithKeplr(props.quote)}
+      {...props}
+    />
+  );
+};

--- a/src/nillion/components/RetrieveSecretForm.tsx
+++ b/src/nillion/components/RetrieveSecretForm.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
-import * as nillion from '@nillion/client-web';
-import { getQuote } from '../helpers/getQuote';
+import React, { useState } from "react";
+import * as nillion from "@nillion/client-web";
+import { getQuote } from "../helpers/getQuote";
 import {
   createNilChainClientAndWalletFromPrivateKey,
-  payWithWalletFromPrivateKey,
-} from '../helpers/nillion';
-import { retrieveSecret } from '../helpers/retrieveSecret';
+  payWithWallet,
+} from "../helpers/nillion";
+import { retrieveSecret } from "../helpers/retrieveSecret";
 import {
   Box,
   Button,
@@ -14,8 +14,8 @@ import {
   ListItem,
   ListItemText,
   TextField,
-} from '@mui/material';
-import PayButton from './PayButton';
+} from "@mui/material";
+import { PayButton } from "./PayButton";
 
 interface RetrieveSecretProps {
   nillionClient: nillion.NillionClient;
@@ -24,8 +24,8 @@ interface RetrieveSecretProps {
 const RetrieveSecret: React.FC<RetrieveSecretProps> = ({
   nillionClient,
 }: RetrieveSecretProps) => {
-  const [storeId, setStoreId] = useState('');
-  const [secretName, setSecretName] = useState('');
+  const [storeId, setStoreId] = useState("");
+  const [secretName, setSecretName] = useState("");
   const [quote, setQuote] = useState<any | null>(null);
   const [paymentReceipt, setPaymentReceipt] = useState<any | null>(null);
   const [retrievedValue, setRetrievedValue] = useState<string | null>(null);
@@ -33,8 +33,8 @@ const RetrieveSecret: React.FC<RetrieveSecretProps> = ({
   const [loadingPayment, setLoadingPayment] = useState(false);
 
   const reset = () => {
-    setStoreId('');
-    setSecretName('');
+    setStoreId("");
+    setSecretName("");
     setQuote(null);
     setPaymentReceipt(null);
     setRetrievedValue(null);
@@ -68,10 +68,10 @@ const RetrieveSecret: React.FC<RetrieveSecretProps> = ({
       const [nilChainClient, nilChainWallet] =
         await createNilChainClientAndWalletFromPrivateKey();
 
-      const paymentReceipt = await payWithWalletFromPrivateKey(
+      const paymentReceipt = await payWithWallet(
         nilChainClient,
         nilChainWallet,
-        quote
+        quote,
       );
 
       setPaymentReceipt(paymentReceipt);
@@ -107,12 +107,12 @@ const RetrieveSecret: React.FC<RetrieveSecretProps> = ({
         margin="normal"
       />
       <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
-        Get Quote{' '}
+        Get Quote{" "}
         {loadingQuote && (
           <CircularProgress
             size="14px"
             color="inherit"
-            style={{ marginLeft: '10px' }}
+            style={{ marginLeft: "10px" }}
           />
         )}
       </Button>

--- a/src/nillion/components/StoreProgramForm.tsx
+++ b/src/nillion/components/StoreProgramForm.tsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
-import * as nillion from '@nillion/client-web';
-import { getQuote } from '../helpers/getQuote';
+import React, { useState, useEffect } from "react";
+import * as nillion from "@nillion/client-web";
+import { getQuote } from "../helpers/getQuote";
 import {
   createNilChainClientAndWalletFromPrivateKey,
-  payWithWalletFromPrivateKey,
-} from '../helpers/nillion';
-import { storeProgram } from '../helpers/storeProgram';
+  payWithWallet,
+} from "../helpers/nillion";
+import { storeProgram } from "../helpers/storeProgram";
 import {
   Box,
   Button,
@@ -17,12 +17,12 @@ import {
   ListItemText,
   MenuItem,
   Select,
-} from '@mui/material';
-import PayButton from './PayButton';
-import { transformNadaProgramToUint8Array } from '../helpers/transformNadaProgramToUint8Array';
-import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
-import python from 'react-syntax-highlighter/dist/esm/languages/hljs/python';
-import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+} from "@mui/material";
+import { PayButton } from "./PayButton";
+import { transformNadaProgramToUint8Array } from "../helpers/transformNadaProgramToUint8Array";
+import { Light as SyntaxHighlighter } from "react-syntax-highlighter";
+import python from "react-syntax-highlighter/dist/esm/languages/hljs/python";
+import { docco } from "react-syntax-highlighter/dist/esm/styles/hljs";
 
 interface StoreProgramProps {
   nillionClient: nillion.NillionClient;
@@ -30,11 +30,11 @@ interface StoreProgramProps {
   onNewStoredProgram?: (data: any) => void;
 }
 
-SyntaxHighlighter.registerLanguage('python', python);
+SyntaxHighlighter.registerLanguage("python", python);
 
 const StoreProgram: React.FC<StoreProgramProps> = ({
   nillionClient,
-  defaultProgram = '',
+  defaultProgram = "",
   onNewStoredProgram,
 }: StoreProgramProps) => {
   const [quote, setQuote] = useState<any | null>(null);
@@ -57,8 +57,8 @@ const StoreProgram: React.FC<StoreProgramProps> = ({
 
   // programs need to have .nada.bin files in public/programs/*
   const selectProgram = [
-    { name: 'addition_simple.nada.bin', value: 'addition_simple' },
-    { name: 'subtraction_simple.nada.bin', value: 'subtraction_simple' },
+    { name: "addition_simple.nada.bin", value: "addition_simple" },
+    { name: "subtraction_simple.nada.bin", value: "subtraction_simple" },
   ];
 
   useEffect(() => {
@@ -79,7 +79,7 @@ const StoreProgram: React.FC<StoreProgramProps> = ({
     if (nillionClient && selectedProgram) {
       setLoadingQuote(true);
       const programBinary = await transformNadaProgramToUint8Array(
-        `./programs/${selectedProgram}.nada.bin`
+        `./programs/${selectedProgram}.nada.bin`,
       );
       const operation = nillion.Operation.store_program(programBinary);
 
@@ -103,10 +103,10 @@ const StoreProgram: React.FC<StoreProgramProps> = ({
       const [nilChainClient, nilChainWallet] =
         await createNilChainClientAndWalletFromPrivateKey();
 
-      const paymentReceipt = await payWithWalletFromPrivateKey(
+      const paymentReceipt = await payWithWallet(
         nilChainClient,
         nilChainWallet,
-        quote
+        quote,
       );
 
       setPaymentReceipt(paymentReceipt);
@@ -160,12 +160,12 @@ const StoreProgram: React.FC<StoreProgramProps> = ({
       )}
 
       <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
-        Get Quote{' '}
+        Get Quote{" "}
         {loadingQuote && (
           <CircularProgress
             size="14px"
             color="inherit"
-            style={{ marginLeft: '10px' }}
+            style={{ marginLeft: "10px" }}
           />
         )}
       </Button>

--- a/src/nillion/components/StoreSecretForm.tsx
+++ b/src/nillion/components/StoreSecretForm.tsx
@@ -1,19 +1,19 @@
-import React, { useState } from 'react';
-import * as nillion from '@nillion/client-web';
-import { NillionClient } from '@nillion/client-web';
-import { storeSecrets } from '../helpers/storeSecrets';
-import { getQuote } from '../helpers/getQuote';
+import React, { useState } from "react";
+import * as nillion from "@nillion/client-web";
+import { NillionClient } from "@nillion/client-web";
+import { storeSecrets } from "../helpers/storeSecrets";
+import { getQuote } from "../helpers/getQuote";
 import {
   createNilChainClientAndWalletFromPrivateKey,
-  payWithWalletFromPrivateKey,
-} from '../helpers/nillion';
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import TextField from '@mui/material/TextField';
-import { CircularProgress, List, ListItem, ListItemText } from '@mui/material';
-import PayButton from './PayButton';
+  payWithWallet,
+} from "../helpers/nillion";
+import Box from "@mui/material/Box";
+import Button from "@mui/material/Button";
+import TextField from "@mui/material/TextField";
+import { CircularProgress, List, ListItem, ListItemText } from "@mui/material";
+import { PayButton } from "./PayButton";
 
-type SecretDataType = 'SecretBlob' | 'SecretInteger';
+type SecretDataType = "SecretBlob" | "SecretInteger";
 
 interface SecretFormProps {
   onNewStoredSecret: (data: any) => void;
@@ -38,12 +38,12 @@ const SecretForm: React.FC<SecretFormProps> = ({
   customSecretName = false,
   secretType,
   hidePermissions = false,
-  itemName = 'secret',
-  defaultUserWithComputePermissions = '',
-  defaultProgramIdForComputePermissions = '',
+  itemName = "secret",
+  defaultUserWithComputePermissions = "",
+  defaultProgramIdForComputePermissions = "",
 }) => {
   const [secretNameFromForm, setSecretNameFromForm] = useState(secretName);
-  const [secret, setSecret] = useState('');
+  const [secret, setSecret] = useState("");
   const [quote, setQuote] = useState<any | null>(null);
   const [paymentReceipt, setPaymentReceipt] = useState<any | null>(null);
   const [storedSecrets, setStoredSecrets] = useState<any | null>([]);
@@ -55,15 +55,15 @@ const SecretForm: React.FC<SecretFormProps> = ({
   const [
     permissionedUserIdForRetrieveSecret,
     setPermissionedUserIdForRetrieveSecret,
-  ] = useState('');
+  ] = useState("");
   const [
     permissionedUserIdForUpdateSecret,
     setPermissionedUserIdForUpdateSecret,
-  ] = useState('');
+  ] = useState("");
   const [
     permissionedUserIdForDeleteSecret,
     setPermissionedUserIdForDeleteSecret,
-  ] = useState('');
+  ] = useState("");
   const [
     permissionedUserIdForComputeSecret,
     setPermissionedUserIdForComputeSecret,
@@ -74,12 +74,12 @@ const SecretForm: React.FC<SecretFormProps> = ({
 
   const reset = () => {
     setSecretNameFromForm(secretName);
-    setSecret('');
+    setSecret("");
     setQuote(null);
     setPaymentReceipt(null);
-    setPermissionedUserIdForRetrieveSecret('');
-    setPermissionedUserIdForUpdateSecret('');
-    setPermissionedUserIdForDeleteSecret('');
+    setPermissionedUserIdForRetrieveSecret("");
+    setPermissionedUserIdForUpdateSecret("");
+    setPermissionedUserIdForDeleteSecret("");
     setPermissionedUserIdForComputeSecret(defaultUserWithComputePermissions);
     setProgramIdForComputePermissions(defaultProgramIdForComputePermissions);
   };
@@ -90,14 +90,14 @@ const SecretForm: React.FC<SecretFormProps> = ({
       setLoadingQuote(true);
       const secretForQuote = new nillion.NadaValues();
 
-      if (secretType === 'SecretBlob') {
+      if (secretType === "SecretBlob") {
         const byteArraySecret = new TextEncoder().encode(secret);
         const newSecretBlob =
           nillion.NadaValue.new_secret_blob(byteArraySecret);
         secretForQuote.insert(secretNameFromForm, newSecretBlob);
       } else {
         const newSecretInteger = nillion.NadaValue.new_secret_integer(
-          secret.toString()
+          secret.toString(),
         );
         secretForQuote.insert(secretNameFromForm, newSecretInteger);
       }
@@ -105,7 +105,7 @@ const SecretForm: React.FC<SecretFormProps> = ({
       const ttl_days = 30;
       const storeOperation = nillion.Operation.store_values(
         secretForQuote,
-        ttl_days
+        ttl_days,
       );
 
       const quote = await getQuote({
@@ -130,10 +130,10 @@ const SecretForm: React.FC<SecretFormProps> = ({
       const [nilChainClient, nilChainWallet] =
         await createNilChainClientAndWalletFromPrivateKey();
 
-      const paymentReceipt = await payWithWalletFromPrivateKey(
+      const paymentReceipt = await payWithWallet(
         nilChainClient,
         nilChainWallet,
-        quote
+        quote,
       );
 
       setPaymentReceipt(paymentReceipt);
@@ -179,7 +179,7 @@ const SecretForm: React.FC<SecretFormProps> = ({
   };
 
   return isLoading ? (
-    'Storing secret...'
+    "Storing secret..."
   ) : (
     <Box component="form" onSubmit={handleGetQuoteSubmit} sx={{ mt: 2 }}>
       <p>Set your secret value. Get a quote, then pay to store the secret.</p>
@@ -198,7 +198,7 @@ const SecretForm: React.FC<SecretFormProps> = ({
       )}
       <TextField
         label={`Set ${itemName} value`}
-        type={secretType === 'SecretBlob' ? 'text' : 'number'}
+        type={secretType === "SecretBlob" ? "text" : "number"}
         value={secret}
         onChange={(e) => setSecret(e.target.value)}
         required
@@ -246,7 +246,7 @@ const SecretForm: React.FC<SecretFormProps> = ({
         />
       )}
 
-      {!hidePermissions && secretType === 'SecretInteger' && (
+      {!hidePermissions && secretType === "SecretInteger" && (
         <TextField
           label="Optional: Set a user id to grant compute permissions to another user"
           value={permissionedUserIdForComputeSecret}
@@ -260,7 +260,7 @@ const SecretForm: React.FC<SecretFormProps> = ({
         />
       )}
 
-      {!hidePermissions && secretType === 'SecretInteger' && (
+      {!hidePermissions && secretType === "SecretInteger" && (
         <TextField
           label="Optional: Set program id for compute permissions"
           value={programIdForComputePermissions}
@@ -273,12 +273,12 @@ const SecretForm: React.FC<SecretFormProps> = ({
       )}
 
       <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
-        Get Quote{' '}
+        Get Quote{" "}
         {loadingQuote && (
           <CircularProgress
             size="14px"
             color="inherit"
-            style={{ marginLeft: '10px' }}
+            style={{ marginLeft: "10px" }}
           />
         )}
       </Button>

--- a/src/nillion/components/UpdateSecretForm.tsx
+++ b/src/nillion/components/UpdateSecretForm.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
-import * as nillion from '@nillion/client-web';
-import { NillionClient } from '@nillion/client-web';
-import { updateSecret } from '../helpers/updateSecret';
-import { getQuote } from '../helpers/getQuote';
+import React, { useState } from "react";
+import * as nillion from "@nillion/client-web";
+import { NillionClient } from "@nillion/client-web";
+import { updateSecret } from "../helpers/updateSecret";
+import { getQuote } from "../helpers/getQuote";
 import {
   createNilChainClientAndWalletFromPrivateKey,
-  payWithWalletFromPrivateKey,
-} from '../helpers/nillion';
+  payWithWallet,
+} from "../helpers/nillion";
 import {
   Box,
   Button,
@@ -19,10 +19,10 @@ import {
   MenuItem,
   Select,
   TextField,
-} from '@mui/material';
-import PayButton from './PayButton';
+} from "@mui/material";
+import { PayButton } from "./PayButton";
 
-type SecretDataType = 'SecretBlob' | 'SecretInteger';
+type SecretDataType = "SecretBlob" | "SecretInteger";
 
 interface UpdateSecretFormProps {
   onNewStoredSecret: (data: any) => void;
@@ -40,12 +40,12 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
   nillionClient,
   isDisabled = false,
   customSecretName = false,
-  itemName = 'secret',
+  itemName = "secret",
 }) => {
   const [secretNameFromForm, setSecretNameFromForm] = useState(secretName);
-  const [secret, setSecret] = useState('');
-  const [secretStoreId, setSecretStoreId] = useState('');
-  const [secretType, setSecretType] = useState<SecretDataType>('SecretBlob');
+  const [secret, setSecret] = useState("");
+  const [secretStoreId, setSecretStoreId] = useState("");
+  const [secretType, setSecretType] = useState<SecretDataType>("SecretBlob");
   const [quote, setQuote] = useState<any | null>(null);
   const [paymentReceipt, setPaymentReceipt] = useState<any | null>(null);
   const [storedSecrets, setStoredSecrets] = useState<any | null>([]);
@@ -56,8 +56,8 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
   const [loadingPayment, setLoadingPayment] = useState(false);
   const reset = () => {
     setSecretNameFromForm(secretName);
-    setSecretStoreId('');
-    setSecret('');
+    setSecretStoreId("");
+    setSecret("");
     setQuote(null);
   };
 
@@ -67,7 +67,7 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
       setLoadingQuote(true);
       const secretForQuote = new nillion.NadaValues();
 
-      if (secretType === 'SecretBlob') {
+      if (secretType === "SecretBlob") {
         const byteArraySecret = new TextEncoder().encode(secret);
         // create new SecretBlob with encoded secret
         const newSecretBlob =
@@ -77,7 +77,7 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
       } else {
         // create new SecretInteger
         const newSecretInteger = nillion.NadaValue.new_secret_integer(
-          secret.toString()
+          secret.toString(),
         );
 
         // insert the SecretInteger into secrets object
@@ -87,7 +87,7 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
       const ttl_days = 30;
       const updateOperation = nillion.Operation.update_values(
         secretForQuote,
-        ttl_days
+        ttl_days,
       );
 
       const quote = await getQuote({
@@ -112,10 +112,10 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
       const [nilChainClient, nilChainWallet] =
         await createNilChainClientAndWalletFromPrivateKey();
 
-      const paymentReceipt = await payWithWalletFromPrivateKey(
+      const paymentReceipt = await payWithWallet(
         nilChainClient,
         nilChainWallet,
-        quote
+        quote,
       );
 
       setPaymentReceipt(paymentReceipt);
@@ -187,7 +187,7 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
 
       <TextField
         label={`Set ${itemName} value`}
-        type={secretType === 'SecretBlob' ? 'text' : 'number'}
+        type={secretType === "SecretBlob" ? "text" : "number"}
         value={secret}
         onChange={(e) => setSecret(e.target.value)}
         required
@@ -198,12 +198,12 @@ const UpdateSecretForm: React.FC<UpdateSecretFormProps> = ({
       />
 
       <Button type="submit" variant="contained" color="primary" sx={{ mt: 2 }}>
-        Get Quote{' '}
+        Get Quote{" "}
         {loadingQuote && (
           <CircularProgress
             size="14px"
             color="inherit"
-            style={{ marginLeft: '10px' }}
+            style={{ marginLeft: "10px" }}
           />
         )}
       </Button>

--- a/src/nillion/helpers/keplr.ts
+++ b/src/nillion/helpers/keplr.ts
@@ -1,0 +1,35 @@
+import { Window as KeplrWindow, Keplr } from "@keplr-wallet/types";
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Window extends KeplrWindow {}
+}
+
+export async function getKeplr(): Promise<Keplr | undefined> {
+  if (window.keplr) {
+    return window.keplr;
+  }
+
+  if (document.readyState === "complete") {
+    return window.keplr;
+  }
+
+  return new Promise((resolve) => {
+    const documentStateChange = (event: Event) => {
+      if (
+        event.target &&
+        (event.target as Document).readyState === "complete"
+      ) {
+        resolve(window.keplr);
+        document.removeEventListener("readystatechange", documentStateChange);
+      }
+    };
+
+    document.addEventListener("readystatechange", documentStateChange);
+  });
+}
+
+export async function signerViaKeplr(chainId: string, keplr: Keplr) {
+  await keplr.enable(chainId);
+  return keplr.getOfflineSigner(chainId);
+}


### PR DESCRIPTION
This PR abstracts creating a Stargate client and wallet with `createNilChainClientAndWallet`, and then the user can choose to use either `createNilChainClientAndWalletFromPrivateKey` and `createNilChainClientAndWalletFromKeplr`. The `payWithWallet` function is unchanged, except for its name (changed everywhere else). It also exports a "Pay with Keplr" button.