### PR TITLE
fix: add missing "await" for an async function call

### DIFF
--- a/src/nillion/helpers/nillion.ts
+++ b/src/nillion/helpers/nillion.ts
@@ -30,7 +30,7 @@ export async function createNilChainClientAndWalletFromPrivateKey(): Promise<
   const wallet = await DirectSecp256k1Wallet.fromKey(key, 'nillion');
 
   const registry = new Registry();
-  registry.register(typeUrl, MsgPayFor);
+  await registry.register(typeUrl, MsgPayFor);
 
   const options = {
     registry,


### PR DESCRIPTION
The `registry.register()` method seems like a promise; maybe it is missing an `await`.