### PR TITLE
solves the issue by adressing some critical changes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,18 +14,18 @@ import BlindInferencePage from './BlindInferencePage';
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <Layout />,
+    element: <Layout />,  // Layout renders for the root path "/"
     children: [
       {
-        path: '/blind-inference',
+        path: 'blind-inference', // Route becomes "/blind-inference"
         element: <BlindInferencePage />,
       },
       {
-        path: '/compute',
+        path: 'compute', // Route becomes "/compute"
         element: <ComputePage />,
       },
       {
-        path: '/',
+        index: true, // Set OperationsPage as the default child route (for "/")
         element: <OperationsPage />,
       },
     ],


### PR DESCRIPTION
Removed duplicate / path: The second definition of the / path that pointed to OperationsPage was removed.
Set OperationsPage as the default route: Instead of giving OperationsPage its own / path, it is now the default child of Layout by using index: true. This way, when the root / is hit, OperationsPage is rendered by default under Layout.